### PR TITLE
翻译完1.4

### DIFF
--- a/content/gtk-questing-index.md
+++ b/content/gtk-questing-index.md
@@ -6,9 +6,23 @@
 
 ##### 常规
 ###1.1
+我如何在GTK+上起步？
+
+GTK+[网站](www.gtk.org)提供了一些[教程](www.gtk.org/documentation.php)和其他文档（大部分是关于GTK+ 2.x的，但大部分依然可用）。更多的从文本资源到在线书籍可以在[GNOME developer's site](https:/developer.gnome.org)中找到。在学习这些材料后，你应该准备回到这个索引来了解细节。
 ###1.2
+我可以在哪里得到GTK+的帮助，提交bug报告或者制作一个特性请求？
+
+参阅[此文档顶部](gtk-resources.md)
 ###1.3
+我如何从一个GTK+版本迁移到另一个？
+
+参阅[Migrating from GTK+2.x to GTK+ 3](https://developer.gnome.org/gtk3/3.14/gtk-migrating-2-to-3.html)。你也许能在这个文档里得到关于某些部件和函数的有用信息。
+如果你有一个手册里所没涵盖的问题，请在邮件列表上提问然后对于文档在[提交一个bug报告](https://bugzilla.gnome.org)。
 ###1.4
+GTK+中的内存管理如何工作？程序返回时我是否要释放数据？
+
+查看[GObject](https://developer.gnome.org/gobject/unstable/gobject-The-Base-Object-Type.html#GObject)和[GInitiallyUnowned]((https://developer.gnome.org/gobject/unstable/gobject-The-Base-Object-Type.html#GInitiallyUnowned)文档。对于GObject特别主义g_object_ref()和g_object_unref()。GInitiallyUnowned是GObject的子类，所以同样注意，特别对于有"floating“状态的（相应文档中有解释）。
+对于函数返回的strings，如果不应该被释放它们要被声明为"const"。非"const"的strings应该被g_free()释放。Arrays遵从同样的规则。如果你发现一个没被记录的特别是规则，请向[http://bugzilla.gnome.org](http://bugzilla.gnome.org)提交bug。
 ###1.5
 ###1.6
 ###1.7


### PR DESCRIPTION
本来想明天在翻译点在提交。我发现gitbook浏览时时有个bug，主要是想告诉你这个
当点击进入1.1.5.x后，再点击任何其他目录都会出现无法找到页面的错误。是链接中多了**..\..** 有空处理下呗
